### PR TITLE
Better ergonomics for imported components

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ struct App;
 impl Component for App {
   fn render(&self) -> VNode {
     h!(div).build(c![
-      MyComponent(&Props::new().insert("prop", &"Hello World!".into()))
+      MyComponent::new().attr("prop", &"Hello World!".into())
       .build(c![]),
     ])
   }

--- a/examples/03-material-ui/src/lib.rs
+++ b/examples/03-material-ui/src/lib.rs
@@ -1,8 +1,6 @@
 use wasm_bindgen::prelude::*;
 use wasm_react::{
-  c, export_components, import_components,
-  props::{Props, Style},
-  Component,
+  c, export_components, import_components, props::Style, Component,
 };
 
 import_components! {
@@ -15,80 +13,68 @@ pub struct App;
 
 impl Component for App {
   fn render(&self) -> wasm_react::VNode {
-    BoxComponent(&Props::new()).build(c![
+    BoxComponent::new().build(c![
       //
-      AppBar(&Props::new()).build(c![
+      AppBar::new().build(c![
         //
-        Toolbar(&Props::new()).build(c![
-          IconButton(
-            &Props::new()
-              .insert("color", &"inherit".into())
-              .insert("edge", &"start".into())
-              .insert("sx", Style::new().margin_right(2).as_ref())
-          )
-          .build(c![MenuIcon(&Props::new()).build(c![])]),
+        Toolbar::new().build(c![
+          IconButton::new()
+            .attr("color", &"inherit".into())
+            .attr("edge", &"start".into())
+            .attr("sx", Style::new().margin_right(2).as_ref())
+            .build(c![MenuIcon::new().build(c![])]),
           //
-          Typography(
-            &Props::new()
-              .insert("variant", &"h6".into())
-              .insert("color", &"inherit".into())
-              .insert("component", &"h1".into())
-              .insert("sx", Style::new().flex_grow(1).as_ref())
-          )
-          .build(c!["MUI Example Application"]),
+          Typography::new()
+            .attr("variant", &"h6".into())
+            .attr("color", &"inherit".into())
+            .attr("component", &"h1".into())
+            .attr("sx", Style::new().flex_grow(1).as_ref())
+            .build(c!["MUI Example Application"]),
         ]),
       ]),
       //
-      Container(
-        &Props::new().insert(
+      Container::new()
+        .attr(
           "sx",
-          &Style::new()
+          Style::new()
             .margin_top(8)
             .padding_top(2)
             .padding_bottom(2)
             .as_ref()
         )
-      )
-      .build(c![
-        //
-        Card(
-          &Props::new()
-            .insert("variant", &"outlined".into())
-            .insert("sx", Style::new().max_width(345).as_ref())
-        )
         .build(c![
           //
-          CardContent(&Props::new()).build(c![
-            //
-            Typography(
-              &Props::new()
-                .insert("variant", &"h5".into())
-                .insert("component", &"h2".into())
-                .insert("sx", &Style::new().margin_bottom(1.5).as_ref())
-            )
-            .build(c!["Hello World!"]),
-            Typography(
-              //
-              &Props::new().insert("variant", &"body2".into())
-            )
+          Card::new()
+            .attr("variant", &"outlined".into())
+            .attr("sx", Style::new().max_width(345).as_ref())
             .build(c![
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit, ",
-              "sed do eiusmod tempor incididunt ut labore et dolore magna ",
-              "aliqua. Ut enim ad minim veniam, quis nostrud exercitation ",
-              "ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis ",
-              "aute irure dolor in reprehenderit in voluptate velit esse ",
-              "cillum dolore eu fugiat nulla pariatur. Excepteur sint ",
-              "occaecat cupidatat non proident, sunt in culpa qui officia ",
-              "deserunt mollit anim id est laborum."
+              //
+              CardContent::new().build(c![
+                //
+                Typography::new()
+                  .attr("variant", &"h5".into())
+                  .attr("component", &"h2".into())
+                  .attr("sx", &Style::new().margin_bottom(1.5).as_ref())
+                  .build(c!["Hello World!"]),
+                Typography::new().attr("variant", &"body2".into()).build(c![
+                  r"Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                  sed do eiusmod tempor incididunt ut labore et dolore magna
+                  aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                  ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                  Duis aute irure dolor in reprehenderit in voluptate velit
+                  esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                  occaecat cupidatat non proident, sunt in culpa qui officia
+                  deserunt mollit anim id est laborum."
+                ])
+              ]),
+              CardActions::new().build(c![
+                //
+                Button::new()
+                  .attr("size", &"small".into())
+                  .build(c!["Learn More"])
+              ])
             ])
-          ]),
-          CardActions(&Props::new()).build(c![
-            //
-            Button(&Props::new().insert("size", &"small".into()))
-              .build(c!["Learn More"])
-          ])
-        ])
-      ]),
+        ]),
     ])
   }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -366,16 +366,12 @@ macro_rules! import_components {
       }
 
       $( #[$meta] )*
-      $vis struct $Name<'a>(pub &'a $crate::props::Props);
+      #[derive(Debug, Clone, Copy)]
+      $vis struct $Name;
 
-      impl<'a> $Name<'a> {
-        /// Returns a `VNode` to be included in a render function.
-        pub fn build(self, children: $crate::VNodeList) -> $crate::VNode {
-          $crate::create_element(
-            &[<__WASMREACT_IMPORT_ $Name:upper>],
-            self.0,
-            children
-          )
+      impl $Name {
+        pub fn new() -> $crate::props::H<&'static JsValue> {
+          $crate::props::H::new(&[<__WASMREACT_IMPORT_ $Name:upper>])
         }
       }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -333,7 +333,7 @@ macro_rules! export_components {
 /// # impl Component for App {
 /// fn render(&self) -> VNode {
 ///   h!(div).build(c![
-///     MyComponent(&Props::new().insert("prop", &"Hello World!".into()))
+///     MyComponent::new().attr("prop", &"Hello World!".into())
 ///     .build(c![])
 ///   ])
 /// }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,13 +41,13 @@
 #[macro_export]
 macro_rules! h {
   ($tag:literal $( [$( #$id:literal )? $( .$( $classnames:tt )+ )?] )?) => {
-    $crate::props::H::new($tag) $(
+    $crate::props::H::new($crate::props::HtmlTag($tag)) $(
       $( .id($id) )?
       $( .class_name(&$crate::classnames![.$( $classnames )+]) )?
     )?
   };
   ($tag:ident $( [$( #$id:literal )? $( .$( $classnames:tt )+ )?] )?) => {
-    $crate::props::H::new(stringify!($tag)) $(
+    $crate::props::H::new($crate::props::HtmlTag(stringify!($tag))) $(
       $( .id($id) )?
       $( .class_name(&$crate::classnames![.$( $classnames )+]) )?
     )?
@@ -370,8 +370,14 @@ macro_rules! import_components {
       $vis struct $Name;
 
       impl $Name {
-        pub fn new() -> $crate::props::H<&'static JsValue> {
-          $crate::props::H::new(&[<__WASMREACT_IMPORT_ $Name:upper>])
+        pub fn new()
+          -> $crate::props::H<$crate::props::ImportedComponent<'static>>
+        {
+          $crate::props::H::new(
+            $crate::props::ImportedComponent(
+              &[<__WASMREACT_IMPORT_ $Name:upper>]
+            )
+          )
         }
       }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,8 @@
 /// A convenience macro to [`create_element()`](crate::create_element()) for
 /// creating HTML element nodes.
 ///
-/// Returns an [`H`](crate::props::H) struct that provides auto-completion for
-/// HTML attributes and events.
+/// Returns an [`H<HtmlTag>`](crate::props::H) struct that provides
+/// auto-completion for HTML attributes and events.
 ///
 /// # Example
 ///
@@ -370,6 +370,8 @@ macro_rules! import_components {
       $vis struct $Name;
 
       impl $Name {
+        /// Returns an `H<ImportedComponent>` struct that provides convenience
+        /// methods for adding props.
         pub fn new()
           -> $crate::props::H<$crate::props::ImportedComponent<'static>>
         {

--- a/src/props/h.rs
+++ b/src/props/h.rs
@@ -29,8 +29,19 @@ impl<'a> AsRef<JsValue> for ImportedComponent<'a> {
   }
 }
 
-#[doc(hidden)]
-pub trait HType {
+mod private {
+  use super::{HtmlTag, ImportedComponent};
+
+  pub trait Sealed {}
+  impl<'a> Sealed for ImportedComponent<'a> {}
+  impl<'a> Sealed for HtmlTag<'a> {}
+}
+
+/// A marker trait for the component type that [`H`] is supposed to build.
+///
+/// Can either be `HtmlTag` or `ImportedComponent`.
+pub trait HType: private::Sealed {
+  #[doc(hidden)]
   fn with_js<T>(&self, f: impl FnOnce(&JsValue) -> T) -> T;
 }
 
@@ -46,8 +57,11 @@ impl<'a> HType for HtmlTag<'a> {
   }
 }
 
-/// The builder that powers [`h!`](crate::h!). This provides auto-completion for
-/// HTML attributes and events.
+/// The component builder that powers [`h!`](crate::h!), which provides
+/// convenience methods for adding props.
+///
+/// In case `T` is `HtmlTag`, [`H<T>`] also provides auto-completion for HTML
+/// attributes and events.
 #[derive(Debug, Clone)]
 pub struct H<T: HType> {
   pub(crate) typ: T,

--- a/src/props/h_attrs.rs
+++ b/src/props/h_attrs.rs
@@ -22,7 +22,7 @@ macro_rules! impl_attr {
 }
 
 /// Provides auto-completion for DOM attributes on [`H`].
-impl<'a> H<'a> {
+impl<'a> H<&'a str> {
   /// Equivalent to `props.dangerouslySetInnerHTML = { __html: value.__html };`.
   ///
   /// See also [React documentation](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml).
@@ -46,7 +46,9 @@ impl<'a> H<'a> {
   pub fn dangerously_set_inner_html(self, value: &DangerousHtml) -> Self {
     self.attr(
       "dangerouslySetInnerHTML",
-      Props::new().insert("__html", &value.__html[..].into()).as_ref(),
+      Props::new()
+        .insert("__html", &value.__html[..].into())
+        .as_ref(),
     )
   }
 

--- a/src/props/h_attrs.rs
+++ b/src/props/h_attrs.rs
@@ -1,4 +1,4 @@
-use super::H;
+use super::{HtmlTag, H};
 use super::{Props, Style};
 use std::borrow::Cow;
 use wasm_bindgen::JsValue;
@@ -22,7 +22,7 @@ macro_rules! impl_attr {
 }
 
 /// Provides auto-completion for DOM attributes on [`H`].
-impl<'a> H<&'a str> {
+impl<'a> H<HtmlTag<'a>> {
   /// Equivalent to `props.dangerouslySetInnerHTML = { __html: value.__html };`.
   ///
   /// See also [React documentation](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml).

--- a/src/props/h_events.rs
+++ b/src/props/h_events.rs
@@ -1,4 +1,4 @@
-use super::H;
+use super::{HtmlTag, H};
 use crate::callback::PersistedCallback;
 use web_sys::{
   AnimationEvent, DragEvent, Event, FocusEvent, KeyboardEvent, MouseEvent,
@@ -17,7 +17,7 @@ macro_rules! impl_event {
 }
 
 /// Provides auto-completion for DOM events on [`H`].
-impl<'a> H<&'a str> {
+impl<'a> H<HtmlTag<'a>> {
   impl_event! {
     on_focus, "onFocus" => FocusEvent;
     on_focus_capture, "onFocusCapture" => FocusEvent;

--- a/src/props/h_events.rs
+++ b/src/props/h_events.rs
@@ -17,7 +17,7 @@ macro_rules! impl_event {
 }
 
 /// Provides auto-completion for DOM events on [`H`].
-impl<'a> H<'a> {
+impl<'a> H<&'a str> {
   impl_event! {
     on_focus, "onFocus" => FocusEvent;
     on_focus_capture, "onFocusCapture" => FocusEvent;

--- a/src/react_bindings/mod.rs
+++ b/src/react_bindings/mod.rs
@@ -8,7 +8,7 @@ extern "C" {
 
   #[wasm_bindgen(js_name = createElement)]
   pub fn create_element(
-    name: &JsValue,
+    typ: &JsValue,
     props: &JsValue,
     children: &JsValue,
   ) -> JsValue;


### PR DESCRIPTION
This changes the `H` struct to be able to build imported components although without the HTML attributes auto-completion.