### PR TITLE
Ergonomic enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the render function, you need to implement the trait `Component` for your
 struct:
 
 ```rust
-use wasm_react::{h, c, Component, VNode};
+use wasm_react::{h, Component, VNode};
 
 struct Counter {
   counter: i32,
@@ -59,10 +59,10 @@ struct Counter {
 impl Component for Counter {
   fn render(&self) -> VNode {
     h!(div)
-      .build(c![
-        h!(p).build(c!["Counter: ", self.counter]),
-        h!(button).build(c!["Increment"]),
-      ])
+      .build((
+        h!(p).build(("Counter: ", self.counter)),
+        h!(button).build("Increment"),
+      ))
   }
 }
 ```
@@ -72,7 +72,7 @@ impl Component for Counter {
 You can use the `use_state()` hook to make your component stateful:
 
 ```rust
-use wasm_react::{h, c, Component, VNode};
+use wasm_react::{h, Component, VNode};
 use wasm_react::hooks::use_state;
 
 struct Counter {
@@ -83,11 +83,12 @@ impl Component for Counter {
   fn render(&self) -> VNode {
     let counter = use_state(|| self.initial_counter);
 
-    h!(div)
-      .build(c![
-        h!(p).build(c!["Counter: ", *counter.value()]),
-        h!(button).build(c!["Increment"]),
-      ])
+    let vnode = h!(div)
+      .build((
+        h!(p).build(("Counter: ", *counter.value())),
+        h!(button).build("Increment"),
+      ));
+    vnode
   }
 }
 ```
@@ -104,7 +105,7 @@ the render function as well, so JS can call it in the future. You can persist a
 closure by using the `use_callback()` hook:
 
 ```rust
-use wasm_react::{h, c, Component, VNode};
+use wasm_react::{h, Component, VNode};
 use wasm_react::hooks::{use_state, use_callback, Deps};
 
 struct Counter {
@@ -120,13 +121,14 @@ impl Component for Counter {
       move |_| counter.set(|c| c + 1)
     }, Deps::none());
 
-    h!(div)
-      .build(c![
-        h!(p).build(c!["Counter: ", *counter.value()]),
+    let value =h!(div)
+      .build((
+        h!(p).build(("Counter: ", *counter.value())),
         h!(button)
           .on_click(&handle_click)
-          .build(c!["Increment"]),
-      ])
+          .build("Increment"),
+      ));
+    value
   }
 }
 ```
@@ -138,7 +140,7 @@ your Rust component for JS consumption. Requirement is that your component
 implements `TryFrom<JsValue, Error = JsValue>`.
 
 ```rust
-use wasm_react::{h, c, export_components, Component, VNode};
+use wasm_react::{h, export_components, Component, VNode};
 use wasm_bindgen::JsValue;
 
 struct Counter {
@@ -156,12 +158,12 @@ struct App;
 
 impl Component for App {
   fn render(&self) -> VNode {
-    h!(div).build(c![
+    h!(div).build((
       Counter {
         initial_counter: 0,
       }
       .build(),
-    ])
+    ))
   }
 }
 
@@ -240,7 +242,7 @@ Make sure the component uses the same React runtime as specified for
 `wasm-react`. Afterwards, use `import_components!`:
 
 ```rust
-use wasm_react::{h, c, import_components, Component, VNode};
+use wasm_react::{h, import_components, Component, VNode};
 use wasm_react::props::Props;
 use wasm_bindgen::prelude::*;
 
@@ -254,11 +256,11 @@ struct App;
 
 impl Component for App {
   fn render(&self) -> VNode {
-    h!(div).build(c![
+    h!(div).build((
       MyComponent::new()
         .attr("prop", &"Hello World!".into())
-        .build(c![]),
-    ])
+        .build(()),
+    ))
   }
 }
 ```
@@ -280,7 +282,7 @@ managed by a state:
 
 ```rust
 use std::rc::Rc;
-use wasm_react::{h, c, Component, VNode};
+use wasm_react::{h, Component, VNode};
 use wasm_react::hooks::{use_state, State};
 
 struct TaskList {
@@ -300,12 +302,12 @@ impl Component for App {
   fn render(&self) -> VNode {
     let tasks: State<Vec<Rc<str>>> = use_state(|| vec![]);
 
-    h!(div).build(c![
+    h!(div).build((
       TaskList {
         tasks: todo!(), // Oops, `tasks.value()` does not fit the type
       }
       .build(),
-    ])
+    ))
   }
 }
 ```
@@ -318,7 +320,7 @@ simply change the type of `TaskList` to a `State`:
 
 ```rust
 use std::rc::Rc;
-use wasm_react::{h, c, Component, VNode};
+use wasm_react::{h, Component, VNode};
 use wasm_react::hooks::{use_state, State};
 
 struct TaskList {
@@ -333,7 +335,7 @@ as possible, you can use `ValueContainer`:
 
 ```rust
 use std::rc::Rc;
-use wasm_react::{h, c, Component, ValueContainer, VNode};
+use wasm_react::{h, Component, ValueContainer, VNode};
 use wasm_react::hooks::{use_state, State};
 
 struct TaskList {
@@ -353,14 +355,14 @@ impl Component for App {
   fn render(&self) -> VNode {
     let tasks: State<Vec<Rc<str>>> = use_state(|| vec![]);
 
-    h!(div).build(c![
+    h!(div).build((
       TaskList {
         // Cloning `State` has low cost as opposed to cloning the underlying
         // `Vec`.
         tasks: tasks.clone().into(),
       }
       .build(),
-    ])
+    ))
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -100,13 +100,12 @@ through the entire lifetime of the component.
 
 ### Add Event Handlers
 
-To create an event handler, you have to keep the lifetime of the closure beyond
-the render function as well, so JS can call it in the future. You can persist a
-closure by using the `use_callback()` hook:
+To create an event handler, you can directly pass your Rust closure to your
+components:
 
 ```rust
 use wasm_react::{h, Component, VNode};
-use wasm_react::hooks::{use_state, use_callback, Deps};
+use wasm_react::hooks::{use_state, Deps};
 
 struct Counter {
   initial_counter: i32,
@@ -115,17 +114,16 @@ struct Counter {
 impl Component for Counter {
   fn render(&self) -> VNode {
     let counter = use_state(|| self.initial_counter);
-    let handle_click = use_callback({
-      let mut counter = counter.clone();
-
-      move |_| counter.set(|c| c + 1)
-    }, Deps::none());
 
     let value =h!(div)
       .build((
         h!(p).build(("Counter: ", *counter.value())),
         h!(button)
-          .on_click(&handle_click)
+          .on_click({
+            let mut counter = counter.clone();
+
+            move |_| counter.set(|c| c + 1)
+          })
           .build("Increment"),
       ));
     value
@@ -150,7 +148,7 @@ struct Counter {
 impl Component for Counter {
   fn render(&self) -> VNode {
     /* … */
-    VNode::empty()
+    VNode::new()
   }
 }
 

--- a/examples/02-todo/src/lib.rs
+++ b/examples/02-todo/src/lib.rs
@@ -1,10 +1,8 @@
 use std::rc::Rc;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 use wasm_react::{
-  callback::Callback,
-  export_components, h,
-  hooks::{use_callback, use_state, Deps},
-  Component, VNode, ValueContainer,
+  callback::Callback, export_components, h, hooks::use_state, Component, VNode,
+  ValueContainer,
 };
 use web_sys::{Event, HtmlInputElement};
 
@@ -23,78 +21,64 @@ impl Component for App {
     let tasks = use_state(|| vec![]);
     let text = use_state(|| Rc::<str>::from(""));
 
-    let handle_submit = use_callback(
-      {
-        let mut tasks = tasks.clone();
-        let mut text = text.clone();
-
-        move |evt: Event| {
-          evt.prevent_default();
-
-          if !text.value().is_empty() {
-            tasks.set(|mut tasks| {
-              tasks.push((false, text.value().clone()));
-              tasks
-            });
-            text.set(|_| "".into());
-          }
-        }
-      },
-      Deps::none(),
-    );
-
-    let handle_input = use_callback(
-      {
-        let mut text = text.clone();
-
-        move |evt: Event| {
-          text.set(|_| {
-            evt
-              .current_target()
-              .unwrap_throw()
-              .dyn_into::<HtmlInputElement>()
-              .unwrap_throw()
-              .value()
-              .into_boxed_str()
-              .into()
-          })
-        }
-      },
-      Deps::none(),
-    );
-
-    let handle_task_change = use_callback(
-      {
-        let mut tasks = tasks.clone();
-
-        move |(id, done): (usize, bool)| {
-          tasks.set(|mut tasks| {
-            tasks.get_mut(id).map(|task: &mut (bool, _)| task.0 = done);
-            tasks
-          })
-        }
-      },
-      Deps::none(),
-    );
-
     let result = h!(div[#"app"]).build((
       h!(h1).build("Todo"),
       //
       TaskList {
         tasks: tasks.clone().into(),
-        on_change: Some(handle_task_change.into()),
+        on_change: Some(Callback::new({
+          let mut tasks = tasks.clone();
+
+          move |(id, done)| {
+            tasks.set(|mut tasks| {
+              tasks.get_mut(id).map(|task: &mut (bool, _)| task.0 = done);
+              tasks
+            })
+          }
+        })),
       }
       .build(),
       //
-      h!(form).on_submit(&handle_submit).build((
-        h!(input)
-          .placeholder("Add new item…")
-          .value(&**text.value())
-          .on_change(&handle_input)
-          .build(()),
-        " ",
-        h!(button).html_type("submit").build(("Add",)),
-      )),
+      h!(form)
+        .on_submit({
+          let mut tasks = tasks.clone();
+          let mut text = text.clone();
+
+          move |evt: Event| {
+            evt.prevent_default();
+
+            if !text.value().is_empty() {
+              tasks.set(|mut tasks| {
+                tasks.push((false, text.value().clone()));
+                tasks
+              });
+              text.set(|_| "".into());
+            }
+          }
+        })
+        .build((
+          h!(input)
+            .placeholder("Add new item…")
+            .value(&**text.value())
+            .on_change({
+              let mut text = text.clone();
+
+              move |evt: Event| {
+                text.set(|_| {
+                  evt
+                    .current_target()
+                    .unwrap_throw()
+                    .dyn_into::<HtmlInputElement>()
+                    .unwrap_throw()
+                    .value()
+                    .into()
+                })
+              }
+            })
+            .build(()),
+          " ",
+          h!(button).html_type("submit").build("Add"),
+        )),
     ));
 
     result
@@ -113,7 +97,7 @@ struct TaskList {
 
 impl Component for TaskList {
   fn render(&self) -> VNode {
-    h!(div[."task-list"]).build((
+    h!(div[."task-list"]).build(
       //
       h!(ul).build(
         self
@@ -134,7 +118,7 @@ impl Component for TaskList {
           })
           .collect::<VNode>(),
       ),
-    ))
+    )
   }
 }
 
@@ -148,45 +132,40 @@ struct TaskItem {
 
 impl Component for TaskItem {
   fn render(&self) -> VNode {
-    let handle_change = use_callback(
-      {
-        let id = self.id;
-
-        self
-          .on_change
-          .clone()
-          .unwrap_or_default()
-          .premap(move |evt: Event| {
-            (
-              id,
-              evt
-                .current_target()
-                .unwrap_throw()
-                .dyn_into::<HtmlInputElement>()
-                .unwrap_throw()
-                .checked(),
-            )
-          })
-          .to_closure()
-      },
-      Deps::some((self.id, self.on_change.clone())),
-    );
-
-    h!(li[."task-item"]).build((
+    h!(li[."task-item"]).build(
       //
       h!(label).build((
         h!(input)
           .html_type("checkbox")
           .checked(self.done)
-          .on_change(&handle_change)
+          .on_change({
+            let id = self.id;
+
+            self
+              .on_change
+              .clone()
+              .unwrap_or_default()
+              .premap(move |evt: Event| {
+                (
+                  id,
+                  evt
+                    .current_target()
+                    .unwrap_throw()
+                    .dyn_into::<HtmlInputElement>()
+                    .unwrap_throw()
+                    .checked(),
+                )
+              })
+              .to_closure()
+          })
           .build(()),
         " ",
         if self.done {
-          h!(del).build((&*self.description,))
+          h!(del).build(&*self.description)
         } else {
           (*self.description).into()
         },
       )),
-    ))
+    )
   }
 }

--- a/examples/02-todo/src/lib.rs
+++ b/examples/02-todo/src/lib.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 use wasm_react::{
-  c,
   callback::Callback,
   export_components, h,
   hooks::{use_callback, use_state, Deps},
@@ -116,9 +115,13 @@ impl Component for TaskList {
   fn render(&self) -> VNode {
     h!(div[."task-list"]).build((
       //
-      h!(ul).build(c![
-        ..self.tasks.value().iter().enumerate().map(
-          |(i, (done, description))| {
+      h!(ul).build(
+        self
+          .tasks
+          .value()
+          .iter()
+          .enumerate()
+          .map(|(i, (done, description))| {
             TaskItem {
               id: i,
               description: description.clone(),
@@ -128,9 +131,9 @@ impl Component for TaskList {
             .memoized()
             .key(Some(i))
             .build()
-          },
-        )
-      ]),
+          })
+          .collect::<VNode>(),
+      ),
     ))
   }
 }

--- a/examples/02-todo/src/lib.rs
+++ b/examples/02-todo/src/lib.rs
@@ -40,7 +40,7 @@ impl Component for App {
       .build(),
       //
       h!(form)
-        .on_submit({
+        .on_submit(&Callback::new({
           let mut tasks = tasks.clone();
           let mut text = text.clone();
 
@@ -55,12 +55,12 @@ impl Component for App {
               text.set(|_| "".into());
             }
           }
-        })
+        }))
         .build((
           h!(input)
             .placeholder("Add new item…")
             .value(&**text.value())
-            .on_change({
+            .on_change(&Callback::new({
               let mut text = text.clone();
 
               move |evt: Event| {
@@ -74,7 +74,7 @@ impl Component for App {
                     .into()
                 })
               }
-            })
+            }))
             .build(()),
           " ",
           h!(button).html_type("submit").build("Add"),
@@ -138,7 +138,7 @@ impl Component for TaskItem {
         h!(input)
           .html_type("checkbox")
           .checked(self.done)
-          .on_change({
+          .on_change(&Callback::new({
             let id = self.id;
 
             self
@@ -157,7 +157,7 @@ impl Component for TaskItem {
                 )
               })
               .to_closure()
-          })
+          }))
           .build(()),
         " ",
         if self.done {

--- a/examples/02-todo/src/lib.rs
+++ b/examples/02-todo/src/lib.rs
@@ -125,14 +125,11 @@ impl Component for TaskItem {
         h!(input)
           .html_type("checkbox")
           .checked(self.done)
-          .on_change(&Callback::new({
+          .on_change(&{
             let id = self.id;
 
-            self
-              .on_change
-              .clone()
-              .unwrap_or_default()
-              .premap(move |evt: Event| {
+            self.on_change.clone().unwrap_or_default().premap(
+              move |evt: Event| {
                 (
                   id,
                   evt
@@ -142,9 +139,9 @@ impl Component for TaskItem {
                     .unwrap_throw()
                     .checked(),
                 )
-              })
-              .to_closure()
-          }))
+              },
+            )
+          })
           .build(()),
         " ",
         if self.done {

--- a/examples/03-material-ui/src/lib.rs
+++ b/examples/03-material-ui/src/lib.rs
@@ -37,7 +37,7 @@ pub struct App;
 impl Component for App {
   fn render(&self) -> wasm_react::VNode {
     BoxComponent::new().build((
-      AppBar::new().build((
+      AppBar::new().build(
         //
         Toolbar::new().build((
           IconButton::new()
@@ -52,7 +52,7 @@ impl Component for App {
             .sx(&Style::new().flex_grow(1))
             .build("MUI Example Application"),
         )),
-      )),
+      ),
       //
       Container::new()
         .sx(&Style::new().margin_top(8).padding_top(2).padding_bottom(2))

--- a/examples/04-context/src/card.rs
+++ b/examples/04-context/src/card.rs
@@ -11,8 +11,8 @@ impl Card {
     Self::default()
   }
 
-  pub fn children(mut self, children: VNode) -> Self {
-    self.children = children;
+  pub fn children(mut self, children: impl Into<VNode>) -> Self {
+    self.children = children.into();
     self
   }
 }

--- a/examples/04-context/src/lib.rs
+++ b/examples/04-context/src/lib.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use wasm_bindgen::JsValue;
 use wasm_react::{
   create_context, export_components, h, hooks::use_state, Component, Context,
-  ContextProvider, VNode,
+  ContextProvider, VNode, callback::Callback,
 };
 
 pub enum Theme {
@@ -47,7 +47,7 @@ impl Component for App {
                   Theme::LightMode => false,
                   Theme::DarkMode => true,
                 })
-                .on_change({
+                .on_change(&Callback::new({
                   let mut theme = theme.clone();
 
                   move |_| {
@@ -59,7 +59,7 @@ impl Component for App {
                       .into()
                     })
                   }
-                })
+                }))
                 .build(()),
               "Dark Mode",
             )),

--- a/examples/04-context/src/lib.rs
+++ b/examples/04-context/src/lib.rs
@@ -6,7 +6,7 @@ use card::Card;
 use std::rc::Rc;
 use wasm_bindgen::JsValue;
 use wasm_react::{
-  c, create_context, export_components, h,
+  create_context, export_components, h,
   hooks::{use_callback, use_state, Deps},
   Component, Context, ContextProvider, VNode,
 };
@@ -48,17 +48,17 @@ impl Component for App {
       Deps::none(),
     );
 
-    h!(div[.{theme_class}]).build(c![
+    let result = h!(div[.{theme_class}]).build(
       //
       ContextProvider::from(&THEME_CONTEXT)
         .value(Some({
           let value = theme.value();
           value.clone()
         }))
-        .build(c![
-          h!(p).build(c![
+        .build((
+          h!(p).build((
             //
-            h!(label).build(c![
+            h!(label).build((
               h!(input)
                 .html_type("checkbox")
                 .checked(match **theme.value() {
@@ -66,23 +66,24 @@ impl Component for App {
                   Theme::DarkMode => true,
                 })
                 .on_change(&handle_toggle_theme)
-                .build(c![]),
-              "Dark Mode"
-            ]),
-          ]),
+                .build(()),
+              "Dark Mode",
+            )),
+          )),
           //
           Card::new()
-            .children(c![
-              h!(p).build(c!["Hello World!"]),
-              h!(p).build(c![
+            .children((
+              h!(p).build("Hello World!"),
+              h!(p).build((
                 Button::new().text("OK").build(),
                 " ",
-                Button::new().text("Cancel").build()
-              ])
-            ])
-            .build()
-        ])
-    ])
+                Button::new().text("Cancel").build(),
+              )),
+            ))
+            .build(),
+        )),
+    );
+    result
   }
 }
 

--- a/examples/04-context/src/lib.rs
+++ b/examples/04-context/src/lib.rs
@@ -6,8 +6,8 @@ use card::Card;
 use std::rc::Rc;
 use wasm_bindgen::JsValue;
 use wasm_react::{
-  create_context, export_components, h, hooks::use_state, Component, Context,
-  ContextProvider, VNode, callback::Callback,
+  callback, create_context, export_components, h, hooks::use_state, Component,
+  Context, ContextProvider, VNode,
 };
 
 pub enum Theme {
@@ -47,18 +47,14 @@ impl Component for App {
                   Theme::LightMode => false,
                   Theme::DarkMode => true,
                 })
-                .on_change(&Callback::new({
-                  let mut theme = theme.clone();
-
-                  move |_| {
-                    theme.set(|theme| {
-                      match *theme {
-                        Theme::LightMode => Theme::DarkMode,
-                        Theme::DarkMode => Theme::LightMode,
-                      }
-                      .into()
-                    })
-                  }
+                .on_change(&callback!(clone(mut theme), move |_| {
+                  theme.set(|theme| {
+                    match *theme {
+                      Theme::LightMode => Theme::DarkMode,
+                      Theme::DarkMode => Theme::LightMode,
+                    }
+                    .into()
+                  })
                 }))
                 .build(()),
               "Dark Mode",

--- a/examples/04-context/src/lib.rs
+++ b/examples/04-context/src/lib.rs
@@ -6,9 +6,8 @@ use card::Card;
 use std::rc::Rc;
 use wasm_bindgen::JsValue;
 use wasm_react::{
-  create_context, export_components, h,
-  hooks::{use_callback, use_state, Deps},
-  Component, Context, ContextProvider, VNode,
+  create_context, export_components, h, hooks::use_state, Component, Context,
+  ContextProvider, VNode,
 };
 
 pub enum Theme {
@@ -31,23 +30,6 @@ impl Component for App {
       Theme::DarkMode => "dark",
     };
 
-    let handle_toggle_theme = use_callback(
-      {
-        let mut theme = theme.clone();
-
-        move |_| {
-          theme.set(|theme| {
-            match *theme {
-              Theme::LightMode => Theme::DarkMode,
-              Theme::DarkMode => Theme::LightMode,
-            }
-            .into()
-          })
-        }
-      },
-      Deps::none(),
-    );
-
     let result = h!(div[.{theme_class}]).build(
       //
       ContextProvider::from(&THEME_CONTEXT)
@@ -65,7 +47,19 @@ impl Component for App {
                   Theme::LightMode => false,
                   Theme::DarkMode => true,
                 })
-                .on_change(&handle_toggle_theme)
+                .on_change({
+                  let mut theme = theme.clone();
+
+                  move |_| {
+                    theme.set(|theme| {
+                      match *theme {
+                        Theme::LightMode => Theme::DarkMode,
+                        Theme::DarkMode => Theme::LightMode,
+                      }
+                      .into()
+                    })
+                  }
+                })
                 .build(()),
               "Dark Mode",
             )),

--- a/src/builtin_components.rs
+++ b/src/builtin_components.rs
@@ -5,38 +5,6 @@ use crate::{
 use std::borrow::Cow;
 use wasm_bindgen::JsValue;
 
-/// Can be used to create a [React fragment][fragment].
-///
-/// [fragment]: https://reactjs.org/docs/fragments.html
-///
-/// # Example
-///
-/// ```
-/// # use wasm_react::*;
-/// #
-/// # fn f() -> VNode {
-/// Fragment::new().build(c![
-///   h!(h1).build(c!["Hello World!"]),
-///   h!(div).build(c!["No wrapper element"]),
-/// ])
-/// # }
-/// ```
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Fragment;
-
-impl HType for Fragment {
-  fn as_js(&self) -> Cow<'_, JsValue> {
-    Cow::Borrowed(&react_bindings::FRAGMENT)
-  }
-}
-
-impl Fragment {
-  /// Creates a new `React.Fragment` component builder.
-  pub fn new() -> H<Fragment> {
-    H::new(Fragment)
-  }
-}
-
 /// A component that specifies the loading indicator when loading lazy descendant
 /// components.
 ///
@@ -56,12 +24,12 @@ impl Fragment {
 /// #
 /// # fn f() -> VNode {
 /// Suspense::new()
-///   .fallback(c![
-///     h!(div[."loading"]).build(c!["Loading…"]),
-///   ])
-///   .build(c![
+///   .fallback(
+///     h!(div[."loading"]).build("Loading…"),
+///   )
+///   .build(
 ///     SomeLazyComponent { /* … */ }.build()
-///   ])
+///   )
 /// # }
 /// ```
 #[derive(Debug, Default, Clone, Copy)]
@@ -82,7 +50,7 @@ impl Suspense {
 
 impl H<Suspense> {
   /// Sets a fallback when loading lazy descendant components.
-  pub fn fallback(self, children: VNode) -> Self {
-    self.attr("fallback", children.as_ref())
+  pub fn fallback(self, children: impl Into<VNode>) -> Self {
+    self.attr("fallback", children.into().as_ref())
   }
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,5 +1,3 @@
-//! This module provides structs to pass Rust closures to JS.
-
 use std::{
   cell::{Ref, RefCell},
   fmt::Debug,
@@ -12,11 +10,11 @@ use wasm_bindgen::{
   JsValue, UnwrapThrowExt,
 };
 
-/// A helper struct to simulate a JS-interoperable [`Callback`] with no input
+/// A zero-sized helper struct to simulate a JS-interoperable [`Callback`] with no input
 /// arguments.
 ///
 /// ```
-/// # use wasm_react::callback::*;
+/// # use wasm_react::*;
 /// # fn f() {
 /// let callback: Callback<Void> = Callback::new(|_: Void| ());
 /// # }
@@ -45,8 +43,11 @@ impl From<Void> for JsValue {
   }
 }
 
-/// This is a simplified, reference-counted wrapper around an [`FnMut`] Rust
-/// closure that may be called from JS when `T` and `U` allow.
+/// This is a simplified, reference-counted wrapper around an [`FnMut(T) -> U`](FnMut)
+/// Rust closure that may be called from JS when `T` and `U` allow.
+///
+/// You can also use the [`callback!`](crate::callback!) macro to create a [`Callback`]
+/// which supports clone-capturing the environment.
 ///
 /// It only supports closures with exactly one input argument and some return
 /// value. Memory management is handled by Rust. Whenever Rust drops all clones
@@ -81,6 +82,12 @@ where
       f(arg)
     }
   }
+
+  /// Calls the callback with the given argument.
+  pub fn call(&self, arg: T) -> U {
+    let mut f = self.closure.borrow_mut();
+    f(arg)
+}
 
   /// Returns a new [`Callback`] by prepending the given closure to the callback.
   pub fn premap<V>(

--- a/src/callback/mod.rs
+++ b/src/callback/mod.rs
@@ -255,7 +255,11 @@ impl<T, U> AsRef<Callback<T, U>> for PersistedCallback<T, U> {
   }
 }
 
-impl<T: 'static, U: 'static> Persisted for PersistedCallback<T, U> {
+impl<T, U> Persisted for PersistedCallback<T, U>
+where
+  T: 'static,
+  U: 'static,
+{
   fn ptr(&self) -> PersistedOrigin {
     PersistedOrigin
   }

--- a/src/component.rs
+++ b/src/component.rs
@@ -27,7 +27,7 @@ pub struct BuildParams {
 ///
 /// impl Component for Counter {
 ///   fn render(&self) -> VNode {
-///     h!(div).build(c!["Counter: ", self.0])
+///     h!(div).build(("Counter: ", self.0))
 ///   }
 /// }
 /// ```
@@ -94,7 +94,7 @@ pub trait Component: Sized + 'static {
   ///
   /// impl Component for MessageBox {
   ///   fn render(&self) -> VNode {
-  ///     h!(h1[."message-box"]).build(c![&*self.message])
+  ///     h!(h1[."message-box"]).build(&*self.message)
   ///   }
   /// }
   ///
@@ -102,13 +102,13 @@ pub trait Component: Sized + 'static {
   ///
   /// impl Component for App {
   ///   fn render(&self) -> VNode {
-  ///     h!(div[#"app"]).build(c![
+  ///     h!(div[#"app"]).build(
   ///       MessageBox {
   ///         message: Rc::from("Hello World!"),
   ///       }
   ///       .memoized()
   ///       .build()
-  ///     ])
+  ///     )
   ///   }
   /// }
   /// ```

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-  c, create_element, hooks::RefContainerValue, props::Props, react_bindings,
+  create_element, hooks::RefContainerValue, props::Props, react_bindings,
   Component, VNode,
 };
 use js_sys::Reflect;
@@ -57,9 +57,9 @@ impl<T> From<Context<T>> for JsValue {
 ///
 ///     ContextProvider::from(&THEME_CONTEXT)
 ///       .value(Some(Theme::DarkMode.into()))
-///       .build(c![
+///       .build(
 ///         Toolbar.build(),
-///       ])
+///       )
 ///   }
 /// }
 ///
@@ -68,7 +68,7 @@ impl<T> From<Context<T>> for JsValue {
 /// impl Component for Toolbar {
 ///   fn render(&self) -> VNode {
 ///     // Theme context does not have to be passed down explicitly.
-///     h!(div).build(c![Button.build()])
+///     h!(div).build(Button.build())
 ///   }
 /// }
 ///
@@ -87,7 +87,7 @@ impl<T> From<Context<T>> for JsValue {
 ///             Theme::DarkMode => "black",
 ///           })
 ///       )
-///       .build(c![])
+///       .build(())
 ///   }
 /// }
 /// ```
@@ -114,7 +114,7 @@ impl<T: 'static> ContextProvider<T> {
     Self {
       context,
       value: None,
-      children: c![],
+      children: ().into(),
     }
   }
 
@@ -125,13 +125,13 @@ impl<T: 'static> ContextProvider<T> {
   }
 
   /// Sets the children of the component.
-  pub fn children(mut self, children: VNode) -> Self {
-    self.children = children;
+  pub fn children(mut self, children: impl Into<VNode>) -> Self {
+    self.children = children.into();
     self
   }
 
   /// Returns a [`VNode`] to be included in a render function.
-  pub fn build(self, children: VNode) -> VNode {
+  pub fn build(self, children: impl Into<VNode>) -> VNode {
     Component::build(self.children(children))
   }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -10,6 +10,7 @@ mod use_js_ref;
 mod use_memo;
 mod use_ref;
 mod use_state;
+mod use_tmp_ref;
 mod use_transition;
 
 pub use deps::*;
@@ -22,4 +23,5 @@ pub use use_js_ref::*;
 pub use use_memo::*;
 pub use use_ref::*;
 pub use use_state::*;
+pub(crate) use use_tmp_ref::*;
 pub use use_transition::*;

--- a/src/hooks/use_callback.rs
+++ b/src/hooks/use_callback.rs
@@ -1,17 +1,14 @@
 use super::{use_memo, Deps};
-use crate::callback::Callback;
+use crate::Callback;
 
 /// Returns a memoized callback.
-pub fn use_callback<T, U, D>(
-  f: impl FnMut(T) -> U + 'static,
-  deps: Deps<D>,
-) -> Callback<T, U>
+pub fn use_callback<T, U, D>(f: Callback<T, U>, deps: Deps<D>) -> Callback<T, U>
 where
   T: 'static,
   U: 'static,
   D: PartialEq + 'static,
 {
-  let memo = use_memo(move || Callback::new(f), deps);
+  let memo = use_memo(move || f, deps);
   let result = memo.value().clone();
 
   result

--- a/src/hooks/use_callback.rs
+++ b/src/hooks/use_callback.rs
@@ -1,18 +1,18 @@
 use super::{use_memo, Deps};
-use crate::callback::{Callback, PersistedCallback};
+use crate::callback::Callback;
 
-/// Returns a persisted, memoized callback.
+/// Returns a memoized callback.
 pub fn use_callback<T, U, D>(
   f: impl FnMut(T) -> U + 'static,
   deps: Deps<D>,
-) -> PersistedCallback<T, U>
+) -> Callback<T, U>
 where
   T: 'static,
   U: 'static,
   D: PartialEq + 'static,
 {
   let memo = use_memo(move || Callback::new(f), deps);
-  let value = memo.value();
+  let result = memo.value().clone();
 
-  PersistedCallback(value.clone())
+  result
 }

--- a/src/hooks/use_context.rs
+++ b/src/hooks/use_context.rs
@@ -1,7 +1,7 @@
+use std::{rc::Rc, thread::LocalKey};
 use wasm_bindgen::UnwrapThrowExt;
 
 use crate::{react_bindings, Context};
-use std::{rc::Rc, thread::LocalKey};
 
 /// Allows access to the current context value of the given context.
 ///

--- a/src/hooks/use_js_ref.rs
+++ b/src/hooks/use_js_ref.rs
@@ -80,12 +80,12 @@ impl<T> From<JsValue> for JsRefContainer<T> {
 ///     let input_element = use_js_ref(None);
 ///
 ///     h!(div)
-///       .build(c![
+///       .build(
 ///         h!(input)
 ///           .ref_container(&input_element)
 ///           .html_type("text")
-///           .build(c![])
-///       ])
+///           .build(())
+///       )
 ///   }
 /// }
 /// ```

--- a/src/hooks/use_memo.rs
+++ b/src/hooks/use_memo.rs
@@ -47,7 +47,8 @@ impl<T> Clone for Memo<T> {
 ///   let b = self.b;
 ///   let memo = use_memo(|| compute_expensive_value(a, b), Deps::some((a, b)));
 ///
-///   h!(div).build(c![*memo.value()])
+///   let vnode = h!(div).build(*memo.value());
+///   vnode
 /// }
 /// # }
 /// ```

--- a/src/hooks/use_ref.rs
+++ b/src/hooks/use_ref.rs
@@ -1,4 +1,4 @@
-use crate::{callback::Void, react_bindings, Persisted, PersistedOrigin};
+use crate::{react_bindings, Persisted, PersistedOrigin};
 use std::{
   any::Any,
   cell::{Ref, RefCell, RefMut},
@@ -115,10 +115,8 @@ pub fn use_ref<T: 'static>(init: T) -> RefContainer<T> {
   let mut value = None;
 
   react_bindings::use_rust_ref(
-    Closure::once(move |_: Void| {
-      RefContainerValue(Rc::new(RefCell::new(init)))
-    })
-    .as_ref(),
+    Closure::once(move || RefContainerValue(Rc::new(RefCell::new(init))))
+      .as_ref(),
     &mut |ref_container_value| {
       value = Some(
         ref_container_value

--- a/src/hooks/use_ref.rs
+++ b/src/hooks/use_ref.rs
@@ -104,9 +104,10 @@ impl<T> Clone for RefContainer<T> {
 ///       }
 ///     }, Deps::some(self.value));
 ///
-///     h!(div).build(c![
+///     let vnode = h!(div).build(
 ///       ref_container.current().value
-///     ])
+///     );
+///     vnode
 ///   }
 /// }
 /// ```

--- a/src/hooks/use_state.rs
+++ b/src/hooks/use_state.rs
@@ -87,7 +87,8 @@ impl<T> Clone for State<T> {
 ///     }
 ///   }, Deps::some(( /* … */ )));
 ///
-///   h!(div).build(c![state.value().greet])
+///   let vnode = h!(div).build(state.value().greet);
+///   vnode
 /// }
 /// # }
 /// ```

--- a/src/hooks/use_state.rs
+++ b/src/hooks/use_state.rs
@@ -1,11 +1,8 @@
 use super::{use_ref, RefContainer};
-use crate::{
-  callback::{Callable, Void},
-  react_bindings, Persisted, PersistedOrigin,
-};
+use crate::{react_bindings, Persisted, PersistedOrigin};
 use js_sys::Function;
 use std::cell::Ref;
-use wasm_bindgen::UnwrapThrowExt;
+use wasm_bindgen::{JsValue, UnwrapThrowExt};
 
 /// Allows access to the underlying state data persisted with [`use_state()`].
 #[derive(Debug)]
@@ -35,7 +32,7 @@ impl<T: 'static> State<T> {
     self.ref_container.set_current(new_value);
     self
       .update
-      .call(&Void.into())
+      .call0(&JsValue::NULL)
       .expect_throw("unable to call state update");
   }
 }

--- a/src/hooks/use_tmp_ref.rs
+++ b/src/hooks/use_tmp_ref.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{prelude::wasm_bindgen, UnwrapThrowExt};
 
 use crate::react_bindings;
 
@@ -7,9 +7,15 @@ use crate::react_bindings;
 #[wasm_bindgen(js_name = __WasmReact_TmpRef)]
 pub struct TmpRef(Box<dyn Any>);
 
-pub fn use_tmp_ref<T>(value: T)
+/// Temporarily persists a value.
+/// 
+/// The value will live until the next rerender.
+pub(crate) fn use_tmp_ref<T>(value: T, mut callback: impl FnMut(&T))
 where
   T: 'static,
 {
-  react_bindings::use_rust_tmp_ref(TmpRef(Box::new(value)).into())
+  react_bindings::use_rust_tmp_ref(
+    TmpRef(Box::new(value)).into(),
+    &mut |tmp_ref| callback(tmp_ref.0.downcast_ref().unwrap_throw()),
+  )
 }

--- a/src/hooks/use_tmp_ref.rs
+++ b/src/hooks/use_tmp_ref.rs
@@ -16,7 +16,7 @@ where
   T: 'static,
 {
   react_bindings::use_rust_tmp_ref(
-    TmpRef(Box::new(value)).into(),
+    TmpRef(Box::new(value)),
     &mut |tmp_ref| callback(tmp_ref.0.downcast_ref().unwrap_throw()),
   )
 }

--- a/src/hooks/use_tmp_ref.rs
+++ b/src/hooks/use_tmp_ref.rs
@@ -9,7 +9,8 @@ pub struct TmpRef(Box<dyn Any>);
 
 /// Temporarily persists a value.
 /// 
-/// The value will live until the next rerender.
+/// The value will live until the next rerender. Callback functions will be 
+/// persisted this way.
 pub(crate) fn use_tmp_ref<T>(value: T, mut callback: impl FnMut(&T))
 where
   T: 'static,

--- a/src/hooks/use_tmp_ref.rs
+++ b/src/hooks/use_tmp_ref.rs
@@ -1,0 +1,15 @@
+use std::any::Any;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::react_bindings;
+
+#[doc(hidden)]
+#[wasm_bindgen(js_name = __WasmReact_TmpRef)]
+pub struct TmpRef(Box<dyn Any>);
+
+pub fn use_tmp_ref<T>(value: T)
+where
+  T: 'static,
+{
+  react_bindings::use_rust_tmp_ref(TmpRef(Box::new(value)).into())
+}

--- a/src/hooks/use_transition.rs
+++ b/src/hooks/use_transition.rs
@@ -1,7 +1,7 @@
 use js_sys::Function;
-use wasm_bindgen::{prelude::Closure, JsCast, UnwrapThrowExt};
+use wasm_bindgen::{prelude::Closure, JsCast, JsValue, UnwrapThrowExt};
 
-use crate::{callback::Callable, react_bindings};
+use crate::react_bindings;
 
 /// Allows access to the transition state.
 #[derive(Debug, Clone)]
@@ -20,7 +20,7 @@ impl Transition {
   pub fn start(&mut self, f: impl FnOnce() + 'static) {
     self
       .start_transition
-      .call(&Closure::once_into_js(f))
+      .call1(&JsValue::NULL, &Closure::once_into_js(f))
       .expect_throw("unable to call start function");
   }
 }
@@ -37,23 +37,21 @@ impl Transition {
 /// let count = use_state(|| 0);
 /// let transition = use_transition();
 ///
-/// let handle_click = use_callback({
-///   let mut transition = transition.clone();
-///
-///   move |_| {
-///     let mut count = count.clone();
-///
-///     transition.start(move || {
-///       count.set(|c| c + 1);
-///     });
-///   }
-/// }, Deps::none());
-///
 /// h!(div).build((
 ///   transition.is_pending().then(||
 ///     h!(div).build("Loading…")
 ///   ),
-///   h!(button).on_click(&handle_click).build(()),
+///   h!(button).on_click({
+///     let mut transition = transition.clone();
+///  
+///     move |_| {
+///       let mut count = count.clone();
+///  
+///       transition.start(move || {
+///         count.set(|c| c + 1);
+///       });
+///     }
+///   }).build(()),
 /// ))
 /// # }
 /// ```

--- a/src/hooks/use_transition.rs
+++ b/src/hooks/use_transition.rs
@@ -49,12 +49,12 @@ impl Transition {
 ///   }
 /// }, Deps::none());
 ///
-/// h!(div).build(c![
+/// h!(div).build((
 ///   transition.is_pending().then(||
-///     h!(div).build(c!["Loading…"])
+///     h!(div).build("Loading…")
 ///   ),
-///   h!(button).on_click(&handle_click).build(c![]),
-/// ])
+///   h!(button).on_click(&handle_click).build(()),
+/// ))
 /// # }
 /// ```
 pub fn use_transition() -> Transition {

--- a/src/hooks/use_transition.rs
+++ b/src/hooks/use_transition.rs
@@ -31,7 +31,7 @@ impl Transition {
 /// # Example
 ///
 /// ```
-/// # use wasm_react::{*, hooks::*, callback::*};
+/// # use wasm_react::{*, hooks::*};
 /// #
 /// # fn render() -> VNode {
 /// let count = use_state(|| 0);
@@ -41,17 +41,13 @@ impl Transition {
 ///   transition.is_pending().then(||
 ///     h!(div).build("Loading…")
 ///   ),
-///   h!(button).on_click({
-///     let mut transition = transition.clone();
-///  
-///     move |_| {
-///       let mut count = count.clone();
-///  
-///       transition.start(move || {
-///         count.set(|c| c + 1);
-///       });
-///     }
-///   }).build(()),
+///   h!(button).on_click(&callback!(clone(mut transition), move |_| {
+///     let mut count = count.clone();
+///
+///     transition.start(move || {
+///       count.set(|c| c + 1);
+///     });
+///   })).build(()),
 /// ))
 /// # }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 extern "C" {}
 
 mod builtin_components;
+mod callback;
 mod component;
 mod context;
 mod macros;
@@ -14,7 +15,6 @@ mod marker;
 mod value_container;
 mod vnode;
 
-pub mod callback;
 pub mod hooks;
 pub mod props;
 #[doc(hidden)]
@@ -24,6 +24,7 @@ use props::Props;
 use wasm_bindgen::prelude::*;
 
 pub use builtin_components::*;
+pub use callback::*;
 pub use component::*;
 pub use context::*;
 pub use marker::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,14 @@ mod component;
 mod context;
 mod macros;
 mod marker;
-mod react_bindings;
 mod value_container;
 mod vnode;
 
 pub mod callback;
 pub mod hooks;
 pub mod props;
+#[doc(hidden)]
+pub mod react_bindings;
 
 use props::Props;
 use wasm_bindgen::prelude::*;
@@ -65,11 +66,7 @@ impl WasmReact {
 /// The Rust equivalent to `React.createElement`. Use [`h!`] for a more
 /// convenient way to create HTML element nodes. To create Rust components, use
 /// [`Component::build()`].
-pub fn create_element(
-  typ: &JsValue,
-  props: &Props,
-  children: VNode,
-) -> VNode {
+pub fn create_element(typ: &JsValue, props: &Props, children: VNode) -> VNode {
   VNode::Single(react_bindings::create_element(
     typ,
     props.as_ref(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,16 +11,16 @@
 /// # fn f() -> VNode {
 /// h!(div)
 ///   .attr("id", &"app".into())
-///   .build(c![
-///     h!(h1).build(c!["Hello World!"])
-///   ])
+///   .build(
+///     h!(h1).build("Hello World!")
+///   )
 /// # }
 ///
 /// // <div id="app"><h1>Hello World!</h1></div>
 ///
 /// # fn g() -> VNode {
 /// h!("web-component")
-///   .build(c!["Hello World!"])
+///   .build("Hello World!")
 /// # }
 ///
 /// // <web-component>Hello World!</web-component>
@@ -33,7 +33,7 @@
 /// # use wasm_react::*;
 /// # fn f() -> VNode {
 /// h!(div[#"app"."some-class"."warning"])
-///   .build(c!["This is a warning!"])
+///   .build("This is a warning!")
 /// # }
 ///
 /// // <div id="app" class="some-class warning">This is a warning!</div>
@@ -51,68 +51,6 @@ macro_rules! h {
       $( .id($id) )?
       $( .class_name(&$crate::classnames![.$( $classnames )+]) )?
     )?
-  };
-}
-
-/// This macro can take various objects to build a [`VNode`].
-///
-/// [`VNode`]: crate::VNode
-///
-/// # Example
-///
-/// ```
-/// # use wasm_react::*;
-/// #
-/// # struct SomeComponent { some_prop: () }
-/// # impl Component for SomeComponent {
-/// #   fn render(&self) -> VNode { VNode::empty() }
-/// # }
-/// #
-/// # fn f(some_prop: (), vec: Vec<&str>, some_bool: bool) -> VNode {
-/// h!(div).build(c![
-///   "Counter: ", 5,
-///
-///   SomeComponent {
-///     some_prop,
-///   }
-///   .build(),
-///
-///   some_bool.then(||
-///     h!(p).build(c!["Conditional rendering"]),
-///   ),
-///
-///   h!(h1).build(c!["Hello World"]),
-///
-///   ..vec.iter()
-///     .map(|x| h!(p).build(c![*x])),
-/// ])
-/// # }
-/// ```
-#[macro_export]
-macro_rules! c {
-  [@single $list:ident <<] => {};
-
-  // Handle iterators
-  [@single $list:ident << ..$vnode_list:expr $(, $( $tail:tt )* )?] => {
-    $list.push(&$vnode_list.collect::<$crate::VNode>().into());
-    $crate::c![@single $list << $( $( $tail )* )?];
-  };
-
-  // Handle `Into<VNode>`
-  [@single $list:ident << $into_vnode:expr $(, $( $tail:tt )* )?] => {
-    $list.push(&$into_vnode.into());
-    $crate::c![@single $list << $( $( $tail )* )?];
-  };
-
-  [] => {
-    $crate::VNode::empty()
-  };
-  [$( $tt:tt )*] => {
-    {
-      let mut list = $crate::VNode::empty();
-      $crate::c![@single list << $( $tt )*];
-      list
-    }
   };
 }
 
@@ -353,11 +291,11 @@ macro_rules! export_components {
 /// # struct App;
 /// # impl Component for App {
 /// fn render(&self) -> VNode {
-///   h!(div).build(c![
+///   h!(div).build(
 ///     MyComponent::new()
 ///       .attr("prop", &"Hello World!".into())
-///       .build(c![])
-///   ])
+///       .build(())
+///   )
 /// }
 /// # }
 /// ```
@@ -386,11 +324,11 @@ macro_rules! export_components {
 /// # struct App;
 /// # impl Component for App {
 /// fn render(&self) -> VNode {
-///   h!(div).build(c![
+///   h!(div).build(
 ///     MyComponent::new()
 ///       .prop("Hello World!")
-///       .build(c![])
-///   ])
+///       .build(())
+///   )
 /// }
 /// # }
 /// ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,7 +146,7 @@ macro_rules! classnames {
 /// }
 ///
 /// impl Component for Counter {
-///   # fn render(&self) -> VNode { VNode::empty() }
+///   # fn render(&self) -> VNode { VNode::new() }
 ///   /* … */
 /// }
 ///
@@ -186,12 +186,12 @@ macro_rules! classnames {
 /// # use wasm_react::*;
 /// # use wasm_bindgen::prelude::*;
 /// # pub struct App; pub struct Counter;
-/// # impl Component for App { fn render(&self) -> VNode { VNode::empty() } }
+/// # impl Component for App { fn render(&self) -> VNode { VNode::new() } }
 /// # impl TryFrom<JsValue> for App {
 /// #   type Error = JsValue;
 /// #   fn try_from(_: JsValue) -> Result<Self, Self::Error> { todo!() }
 /// # }
-/// # impl Component for Counter { fn render(&self) -> VNode { VNode::empty() } }
+/// # impl Component for Counter { fn render(&self) -> VNode { VNode::new() } }
 /// # impl TryFrom<JsValue> for Counter {
 /// #   type Error = JsValue;
 /// #   fn try_from(_: JsValue) -> Result<Self, Self::Error> { todo!() }
@@ -237,8 +237,9 @@ macro_rules! export_components {
           move || $Component::try_from(props).unwrap()
         }, $crate::hooks::Deps::some(props));
 
-        let component = component_ref.value();
+        $crate::react_bindings::use_rust_tmp_refs();
 
+        let component = component_ref.value();
         $crate::Component::render(&*component).into()
       }
     }
@@ -265,7 +266,7 @@ macro_rules! export_components {
 /// export function RenamedComponent(props) { /* … */ }
 /// ```
 ///
-/// Then you can import them using [`import_components!`]:
+/// Then you can import them using `import_components!`:
 ///
 /// ```
 /// # use wasm_react::*;

--- a/src/props/h.rs
+++ b/src/props/h.rs
@@ -1,5 +1,7 @@
 use super::Props;
-use crate::{create_element, hooks::JsRefContainer, KeyType, VNode};
+use crate::{
+  callback::Callback, create_element, hooks::JsRefContainer, KeyType, VNode,
+};
 use std::borrow::Cow;
 use wasm_bindgen::{
   convert::{FromWasmAbi, IntoWasmAbi},
@@ -77,7 +79,7 @@ impl<T: HType> H<T> {
   /// [ref]: https://reactjs.org/docs/refs-and-the-dom.html
   pub fn ref_callback(
     mut self,
-    ref_callback: impl FnMut(Option<Element>) + 'static,
+    ref_callback: &Callback<Option<Element>>,
   ) -> Self {
     self.props = self.props.ref_callback(ref_callback);
     self
@@ -90,11 +92,7 @@ impl<T: HType> H<T> {
   }
 
   /// Sets a callback value to an attribute on the [`VNode`].
-  pub fn attr_callback<U, V>(
-    mut self,
-    key: &str,
-    f: impl FnMut(U) -> V + 'static,
-  ) -> Self
+  pub fn attr_callback<U, V>(mut self, key: &str, f: &Callback<U, V>) -> Self
   where
     U: FromWasmAbi + 'static,
     V: IntoWasmAbi + 'static,

--- a/src/props/h.rs
+++ b/src/props/h.rs
@@ -1,8 +1,5 @@
 use super::Props;
-use crate::{
-  callback::PersistedCallback, create_element, hooks::JsRefContainer, KeyType,
-  VNode,
-};
+use crate::{create_element, hooks::JsRefContainer, KeyType, VNode};
 use std::borrow::Cow;
 use wasm_bindgen::{
   convert::{FromWasmAbi, IntoWasmAbi},
@@ -80,7 +77,7 @@ impl<T: HType> H<T> {
   /// [ref]: https://reactjs.org/docs/refs-and-the-dom.html
   pub fn ref_callback(
     mut self,
-    ref_callback: &PersistedCallback<Option<Element>>,
+    ref_callback: impl FnMut(Option<Element>) + 'static,
   ) -> Self {
     self.props = self.props.ref_callback(ref_callback);
     self
@@ -96,7 +93,7 @@ impl<T: HType> H<T> {
   pub fn attr_callback<U, V>(
     mut self,
     key: &str,
-    f: &PersistedCallback<U, V>,
+    f: impl FnMut(U) -> V + 'static,
   ) -> Self
   where
     U: FromWasmAbi + 'static,
@@ -106,8 +103,7 @@ impl<T: HType> H<T> {
     self
   }
 
-  /// Builds the [`VNode`] and returns it with the given children. Use
-  /// [`c!`](crate::c!) for easier construction of the children.
+  /// Builds the [`VNode`] and returns it with the given children.
   pub fn build(self, children: impl Into<VNode>) -> VNode {
     create_element(&self.typ.as_js(), &self.props, children.into())
   }

--- a/src/props/h.rs
+++ b/src/props/h.rs
@@ -1,6 +1,6 @@
 use super::Props;
 use crate::{
-  callback::Callback, create_element, hooks::JsRefContainer, KeyType, VNode,
+  Callback, create_element, hooks::JsRefContainer, KeyType, VNode,
 };
 use std::borrow::Cow;
 use wasm_bindgen::{

--- a/src/props/h_attrs.rs
+++ b/src/props/h_attrs.rs
@@ -40,7 +40,7 @@ impl H<HtmlTag<'_>> {
   /// # fn f() -> VNode {
   /// h!(div)
   ///   .dangerously_set_inner_html(&create_markup())
-  ///   .build(c![])
+  ///   .build(())
   /// # }
   /// ```
   pub fn dangerously_set_inner_html(self, value: &DangerousHtml) -> Self {

--- a/src/props/h_events.rs
+++ b/src/props/h_events.rs
@@ -5,7 +5,7 @@ use web_sys::{
   PointerEvent, TransitionEvent, UiEvent, WheelEvent,
 };
 
-use crate::callback::Callback;
+use crate::Callback;
 
 macro_rules! impl_event {
   { $( $on_event:ident, $on_event_str:literal => $E:ty; )* } => {

--- a/src/props/h_events.rs
+++ b/src/props/h_events.rs
@@ -1,5 +1,4 @@
 use super::{HtmlTag, H};
-use crate::callback::PersistedCallback;
 use wasm_bindgen::intern;
 use web_sys::{
   AnimationEvent, DragEvent, Event, FocusEvent, KeyboardEvent, MouseEvent,
@@ -10,7 +9,7 @@ macro_rules! impl_event {
   { $( $on_event:ident, $on_event_str:literal => $E:ty; )* } => {
     $(
       #[allow(missing_docs)]
-      pub fn $on_event(self, f: &PersistedCallback<$E>) -> Self {
+      pub fn $on_event(self, f: impl FnMut($E) + 'static) -> Self {
         self.attr_callback(intern($on_event_str), f)
       }
     )*

--- a/src/props/h_events.rs
+++ b/src/props/h_events.rs
@@ -5,11 +5,13 @@ use web_sys::{
   PointerEvent, TransitionEvent, UiEvent, WheelEvent,
 };
 
+use crate::callback::Callback;
+
 macro_rules! impl_event {
   { $( $on_event:ident, $on_event_str:literal => $E:ty; )* } => {
     $(
       #[allow(missing_docs)]
-      pub fn $on_event(self, f: impl FnMut($E) + 'static) -> Self {
+      pub fn $on_event(self, f: &Callback<$E>) -> Self {
         self.attr_callback(intern($on_event_str), f)
       }
     )*

--- a/src/props/props.rs
+++ b/src/props/props.rs
@@ -1,7 +1,6 @@
 use crate::{
-  callback::Callback,
   hooks::{use_tmp_ref, JsRefContainer},
-  KeyType,
+  Callback, KeyType,
 };
 use js_sys::{Object, Reflect};
 use wasm_bindgen::{
@@ -18,7 +17,7 @@ use wasm_bindgen::{
 /// # Example
 ///
 /// ```
-/// # use wasm_react::{callback::*, props::*};
+/// # use wasm_react::{*, props::*};
 /// # use wasm_bindgen::prelude::*;
 /// #
 /// # fn f(handle_click: &Callback<Void>) -> Props {

--- a/src/react_bindings/mod.rs
+++ b/src/react_bindings/mod.rs
@@ -34,6 +34,9 @@ extern "C" {
     callback: &mut dyn FnMut(&RefContainerValue),
   );
 
+  #[wasm_bindgen(js_name = useRustTmpRef)]
+  pub fn use_rust_tmp_ref(value: JsValue);
+
   #[wasm_bindgen(js_name = useRustState)]
   pub fn use_rust_state() -> Function;
 

--- a/src/react_bindings/mod.rs
+++ b/src/react_bindings/mod.rs
@@ -41,7 +41,7 @@ extern "C" {
   pub fn use_rust_tmp_refs();
 
   #[wasm_bindgen(js_name = useRustTmpRef)]
-  pub fn use_rust_tmp_ref(value: JsValue, callback: &mut dyn FnMut(&TmpRef));
+  pub fn use_rust_tmp_ref(value: TmpRef, callback: &mut dyn FnMut(&TmpRef));
 
   #[wasm_bindgen(js_name = useRustState)]
   pub fn use_rust_state() -> Function;

--- a/src/react_bindings/mod.rs
+++ b/src/react_bindings/mod.rs
@@ -1,4 +1,7 @@
-use crate::{hooks::RefContainerValue, ComponentWrapper, MemoComponentWrapper};
+use crate::{
+  hooks::{RefContainerValue, TmpRef},
+  ComponentWrapper, MemoComponentWrapper,
+};
 use js_sys::{Array, Function};
 use wasm_bindgen::prelude::*;
 
@@ -34,8 +37,11 @@ extern "C" {
     callback: &mut dyn FnMut(&RefContainerValue),
   );
 
+  #[wasm_bindgen(js_name = useRustTmpRefs)]
+  pub fn use_rust_tmp_refs();
+
   #[wasm_bindgen(js_name = useRustTmpRef)]
-  pub fn use_rust_tmp_ref(value: JsValue);
+  pub fn use_rust_tmp_ref(value: JsValue, callback: &mut dyn FnMut(&TmpRef));
 
   #[wasm_bindgen(js_name = useRustState)]
   pub fn use_rust_state() -> Function;


### PR DESCRIPTION
- **BREAKING:** Removed `c!` and `Fragment`, instead build up children using a tuple, e.g. 

  ```rs
  h!(div).build((
    h!(h1).build("Hello"),
    h!(h2).build("World!")
  ))
  ```
- **BREAKING:** Removed `Callable` trait and `PersistedCallback`, only `Callback` and `Void` are left of the previous `wasm_react::callback` module and moved to `wasm_react::Callback` and `wasm_react::Void`. Callbacks can now be passed directly into props without persisting them with `use_callback()` first.
- **BREAKING:** Removed `VNodeList`, replaced by `VNode`. `VNode` is now an enum. `VNode::empty()` has been renamed to `VNode::new()`.
- Added `callback!` macro to create `Callback`'s which can clone-capture its environment.